### PR TITLE
docs: change Github to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# Github App for Splunk
+# GitHub App for Splunk
 
-The Github App for Splunk is a collection of out of the box dashboards and Splunk knowledge objects designed to give Github Admins and platform owners immediate visibility into Github.
+The GitHub App for Splunk is a collection of out of the box dashboards and Splunk knowledge objects designed to give GitHub Admins and platform owners immediate visibility into GitHub.
 
-This App is designed to work across multiple Github data sources however not all all required. You may choose to only collect a certain set of data and the parts of this app that utilize that set will function, while those that use other data sources will not function correctly, so please only use the Dashboards that relate to the data you are collecting.
+This App is designed to work across multiple GitHub data sources however not all all required. You may choose to only collect a certain set of data and the parts of this app that utilize that set will function, while those that use other data sources will not function correctly, so please only use the Dashboards that relate to the data you are collecting.
 
-The Github App for Splunk is designed to work with the following data sources:
+The GitHub App for Splunk is designed to work with the following data sources:
 
-* [Github Audit Log Monitoring Add-On For Splunk](./docs/ghe_audit_logs.MD): Audit logs from Github Enterprise Cloud.
+* [GitHub Audit Log Monitoring Add-On For Splunk](./docs/ghe_audit_logs.MD): Audit logs from GitHub Enterprise Cloud.
 * [Github.com Webhooks](./docs/github_webhooks.MD): A select set of webhook events like Push, PullRequest, and Repo.
-* [Github Enterprise Server Syslog Forwarder](https://docs.github.com/en/enterprise-server/admin/user-management/monitoring-activity-in-your-enterprise/log-forwarding): Audit and Application logs from Github Enterprise Server.
-* [Github Enterprise Collectd monitoring](./docs/splunk_collectd_forwarding_for_ghes.MD): Performance and Infrastructure metrics from Github Enterprise Server.
+* [GitHub Enterprise Server Syslog Forwarder](https://docs.github.com/en/enterprise-server/admin/user-management/monitoring-activity-in-your-enterprise/log-forwarding): Audit and Application logs from GitHub Enterprise Server.
+* [GitHub Enterprise Collectd monitoring](./docs/splunk_collectd_forwarding_for_ghes.MD): Performance and Infrastructure metrics from GitHub Enterprise Server.
 
 ## Dashboard Instructions
 
 ### Installation
 
-The Github App for Splunk is available for download from [Splunkbase](https://splunkbase.splunk.com/app/5596/). For Splunk Cloud, refer to [Install apps in your Splunk Cloud deployment](https://docs.splunk.com/Documentation/SplunkCloud/latest/Admin/SelfServiceAppInstall). For non-Splunk Cloud deployments, refer to the standard methods for Splunk Add-on installs as documented for a [Single Server Install](http://docs.splunk.com/Documentation/AddOns/latest/Overview/Singleserverinstall) or a [Distributed Environment Install](http://docs.splunk.com/Documentation/AddOns/latest/Overview/Distributedinstall).
+The GitHub App for Splunk is available for download from [Splunkbase](https://splunkbase.splunk.com/app/5596/). For Splunk Cloud, refer to [Install apps in your Splunk Cloud deployment](https://docs.splunk.com/Documentation/SplunkCloud/latest/Admin/SelfServiceAppInstall). For non-Splunk Cloud deployments, refer to the standard methods for Splunk Add-on installs as documented for a [Single Server Install](http://docs.splunk.com/Documentation/AddOns/latest/Overview/Singleserverinstall) or a [Distributed Environment Install](http://docs.splunk.com/Documentation/AddOns/latest/Overview/Distributedinstall).
 
 **This app should be installed on both your search head tier as well as your indexer tier.**
  
@@ -23,14 +23,14 @@ The Github App for Splunk is available for download from [Splunkbase](https://sp
 
 ![Settings>Advanced Search>Search macros](./docs/images/macros.png)
 
-1. The Github App for Splunk uses macros so that index and `sourcetype` names don't need to be updated in each dashboard panel. You'll need to update the macros to account for your selected indexes.
-1. The macro `github_source` is the macro for all audit log events, whether from Github Enterprise Cloud or Server. The predefined macro includes examples of **BOTH**. Update to account for your specific needs.
+1. The GitHub App for Splunk uses macros so that index and `sourcetype` names don't need to be updated in each dashboard panel. You'll need to update the macros to account for your selected indexes.
+1. The macro `github_source` is the macro for all audit log events, whether from GitHub Enterprise Cloud or Server. The predefined macro includes examples of **BOTH**. Update to account for your specific needs.
 1. The macro `github_webhooks` is the macro used for all webhook events. Since it is assuming a single index for all webhook events, that is the predefined example, but update as needed.
-1. Finally, the macro `github_collectd` is the macro used for all `collectd` metrics sent from Github Enterprise Server. Please update accordingly.
+1. Finally, the macro `github_collectd` is the macro used for all `collectd` metrics sent from GitHub Enterprise Server. Please update accordingly.
 
 ### Integration Overview dashboard
 
-There is an *Integration Overview* dashboard listed under *Dashboards* that allows you to monitor API rate limits, audit events fetched, or webhooks received. This dashboard is primarily meant to be used with the `Github Audit Log Monitoring Add-On for Splunk` and uses internal Splunk logs. To be able to view them you will probably need elevated privileges in Splunk that include access to the `_internal` index. Please coordinate with your Splunk team if that dashboard is desired.
+There is an *Integration Overview* dashboard listed under *Dashboards* that allows you to monitor API rate limits, audit events fetched, or webhooks received. This dashboard is primarily meant to be used with the `GitHub Audit Log Monitoring Add-On for Splunk` and uses internal Splunk logs. To be able to view them you will probably need elevated privileges in Splunk that include access to the `_internal` index. Please coordinate with your Splunk team if that dashboard is desired.
 
 ### Examples
 
@@ -59,4 +59,4 @@ There is an *Integration Overview* dashboard listed under *Dashboards* that allo
 
 ## Support
 
-Support for Github App for Splunk is run through [Github Issues](https://github.com/splunk/github_app_for_splunk/issues). Please open a new issue for any support issues or for feature requests. You may also open a Pull Request if you'd like to contribute additional dashboards, eventtypes for webhooks, or enhancements you may have.
+Support for GitHub App for Splunk is run through [GitHub Issues](https://github.com/splunk/github_app_for_splunk/issues). Please open a new issue for any support issues or for feature requests. You may also open a Pull Request if you'd like to contribute additional dashboards, eventtypes for webhooks, or enhancements you may have.

--- a/docs/ghe_audit_logs.MD
+++ b/docs/ghe_audit_logs.MD
@@ -125,7 +125,7 @@ This modular input fetches events by calling the [Enterprise Audit Log API](http
 
 ### Activity dashboard example
 
-Along with this modular input we're providing a [Github App for Splunk](https://github.com/splunk/github_app_for_splunk) that makes use of the collected audit log events to give you an overview of the activities across your enterprise.
+Along with this modular input we're providing a [GitHub App for Splunk](https://github.com/splunk/github_app_for_splunk) that makes use of the collected audit log events to give you an overview of the activities across your enterprise.
 
 You can install it via the [Manage Apps page](https://docs.splunk.com/Documentation/Splunk/8.2.0/Admin/Deployappsandadd-ons).
 

--- a/docs/github_webhooks.MD
+++ b/docs/github_webhooks.MD
@@ -1,10 +1,10 @@
-# Using Github Webhooks
+# Using GitHub Webhooks
 
-Github Webhooks are a great way to collect rich information as it occurs. You can easily enable webhooks within the Github UI and can even select specific actions on which to trigger a webhook call to Splunk. This is only available at the Organization level and will require this to be done for each Org as desired. To do so, you'll need to configure Splunk as a receiver and then setup the webhooks within Github.
+GitHub Webhooks are a great way to collect rich information as it occurs. You can easily enable webhooks within the GitHub UI and can even select specific actions on which to trigger a webhook call to Splunk. This is only available at the Organization level and will require this to be done for each Org as desired. To do so, you'll need to configure Splunk as a receiver and then setup the webhooks within GitHub.
 
 ## Configuring Splunk to receive Webhooks
 
-Splunk's HTTP Event Collector (HEC) is a quick and easy endpoint built to receive data from other producers like Github.
+Splunk's HTTP Event Collector (HEC) is a quick and easy endpoint built to receive data from other producers like GitHub.
 
 ### Setting Up Splunk to Listen for Webhooks
 1. Under Settings > Data Inputs, click **HTTP Event Collector**
@@ -13,19 +13,19 @@ Splunk's HTTP Event Collector (HEC) is a quick and easy endpoint built to receiv
 1. Unless required by your Splunk administrator, the rest of this page can be left as is and continue onto the next step.
 1. You'll want to click `select` for Source Type, and a new selection box will appear below that.
 1. Under the Application option, there should be an entry for `github_json`, however you may need to use the little search bar to find it.
-1. For App Context, you'll want to select **Splunk App for Github**</li>
+1. For App Context, you'll want to select **Splunk App for GitHub**</li>
 1. Next select the index created for this data. If none exist, create a new Index. Names like `github` or the like are recommended, depending on corporate naming conventions.
 1. Lastly, click the Review button and confirm the data is correct and hit Submit.
 
 Your token is now available to collect data, however we'll need to enable that token to allow Query String Authentication using that token. For this, you'll need command line access to your Splunk environment or be using a deployment server to deploy apps to Splunk.
 
-To enable Query String Authentication, you'll need to update the `inputs.conf` file within the Splunk App for Github local directory. In that file, there will be a stanza with the name and value of the token you created. At the end of that stanza, you'll need to add `allowQueryStringAuth = true` and then restart Splunk. This is best done with the help of your Splunk team, so please reach out to them for assistance on this step.
+To enable Query String Authentication, you'll need to update the `inputs.conf` file within the Splunk App for GitHub local directory. In that file, there will be a stanza with the name and value of the token you created. At the end of that stanza, you'll need to add `allowQueryStringAuth = true` and then restart Splunk. This is best done with the help of your Splunk team, so please reach out to them for assistance on this step.
 
-### Setting Up Github Webhooks
+### Setting Up GitHub Webhooks
 
 Webhooks are a simple push mechanism that will send an event each time the webhook is triggered. Unfortunately, Webhooks are unique to each Organization and will need to be setup for each Org as desired. To do this, a user will need to be an Admin for the Org.
 
-1. In your Github Organization Settings page, select Webhooks from the menu on the left.
+1. In your GitHub Organization Settings page, select Webhooks from the menu on the left.
 1. On this page, you'll see all the existing Webhooks, click the **Add webhook** button to add one to send data to Splunk.
 1. The Payload URL will be the Splunk HTTP Event Collector endpoint that was enabled above. It should look something like: `https://YOUR SPLUNK URL:8088/services/collector/raw?token=THE TOKEN FROM ABOVE`. The default port of 8088 may be different for your Splunk Environment, so please confirm the HEC port with your Splunk Admin team.
 1. For Content Type, you'll want to select `application/json` as the best option.
@@ -41,26 +41,26 @@ Once that is complete and webhooks are triggering, you'll want to update the mac
 <table>
 <tr>
 <th>Splunk Eventtype</th>
-<th>Github Webhook Event</th>
+<th>GitHub Webhook Event</th>
 <th>Description</th>
 </tr>
 <tr>
-<td>Github::Repo</td>
+<td>GitHub::Repo</td>
 <td>Repositories</td>
 <td>Repository created, deleted, archived, unarchived, publicized, privatized, edited, renamed, or transferred.</td>
 </tr>
 <tr>
-<td>Github::Push</td>
+<td>GitHub::Push</td>
 <td>Pushes</td>
 <td>Git push to a repository.</td>
 </tr>
 <tr>
-<td>Github::PullRequest</td>
+<td>GitHub::PullRequest</td>
 <td>Pull requests</td>
 <td>Pull request opened, closed, reopened, edited, assigned, unassigned, review requested, review request removed, labeled, unlabeled, synchronized, ready for review, converted to draft, locked, unlocked, auto merge enabled, auto merge disabled, milestoned, or demilestoned.</td>
 </tr>
 <tr>
-<td>Github::PullRequest::Review</td>
+<td>GitHub::PullRequest::Review</td>
 <td>Pull request reviews</td>
 <td>Pull request review submitted, edited, or dismissed.</td>
 </tr>

--- a/docs/splunk_collectd_forwarding_for_ghes.MD
+++ b/docs/splunk_collectd_forwarding_for_ghes.MD
@@ -1,4 +1,4 @@
-# Splunk Collectd Forwarding for Github Enterprise Server
+# Splunk Collectd Forwarding for GitHub Enterprise Server
 
 This guide describes how to enable collectd forwarding on GitHub Enterprise Server (GHES) using Splunk Enterprise (v8.0+).
 

--- a/github_app_for_splunk/README.md
+++ b/github_app_for_splunk/README.md
@@ -1,30 +1,30 @@
-# Github App for Splunk
+# GitHub App for Splunk
 
-The Github App for Splunk is a collection of out of the box dashboards and Splunk knowledge objects designed to give Github Admins and platform owners immediate visibility into Github.
+The GitHub App for Splunk is a collection of out of the box dashboards and Splunk knowledge objects designed to give GitHub Admins and platform owners immediate visibility into GitHub.
 
-This App is designed to work across multiple Github data sources however not all all required. You may choose to only collect a certain set of data and the parts of this app that utilize that set will function, while those that use other data sources will not function correctly, so please only use the Dashboards that relate to the data you are collecting.
+This App is designed to work across multiple GitHub data sources however not all all required. You may choose to only collect a certain set of data and the parts of this app that utilize that set will function, while those that use other data sources will not function correctly, so please only use the Dashboards that relate to the data you are collecting.
 
-The Github App for Splunk is designed to work with the following data sources:
+The GitHub App for Splunk is designed to work with the following data sources:
 
-* [Github Audit Log Monitoring Add-On For Splunk](./docs/ghe_audit_logs.MD): Audit logs from Github Enterprise Cloud.
+* [GitHub Audit Log Monitoring Add-On For Splunk](./docs/ghe_audit_logs.MD): Audit logs from GitHub Enterprise Cloud.
 * [Github.com Webhooks]((./docs/github_webhooks.MD)): A select set of webhook events like Push, PullRequest, and Repo.
-* [Github Enterprise Server Syslog Forwarder](https://docs.github.com/en/enterprise-server@3.0/admin/user-management/monitoring-activity-in-your-enterprise/log-forwarding): Audit and Application logs from Github Enterprise Server.
-* [Github Enterprise Collectd monitoring](./docs/splunk_collectd_forwarding_for_ghes.MD): Performance and Infrastructure metrics from Github Enterprise Server.
+* [GitHub Enterprise Server Syslog Forwarder](https://docs.github.com/en/enterprise-server@3.0/admin/user-management/monitoring-activity-in-your-enterprise/log-forwarding): Audit and Application logs from GitHub Enterprise Server.
+* [GitHub Enterprise Collectd monitoring](./docs/splunk_collectd_forwarding_for_ghes.MD): Performance and Infrastructure metrics from GitHub Enterprise Server.
 
 ## Dashboard Instructions
 
-The Github App for Splunk is available for download from [Splunkbase](https://splunkbase.splunk.com/app/5596/). Once installed there are a couple steps needed to light up all the dashboards.
+The GitHub App for Splunk is available for download from [Splunkbase](https://splunkbase.splunk.com/app/5596/). Once installed there are a couple steps needed to light up all the dashboards.
 
 ![Settings>Advanced Search>Search macros](./docs/images/macros.png)
-1. The Github App for Splunk uses macros so that index and sourcetype names don't need to be updated in each dashboard panel. You'll need to update the macros to account for your selected indexes.
-1. The macro `github_source` is the macro for all audit log events, whether from Github Enterprise Cloud or Server. The predefined maco includes examples of **BOTH**. Update to account for your specific needs.
+1. The GitHub App for Splunk uses macros so that index and sourcetype names don't need to be updated in each dashboard panel. You'll need to update the macros to account for your selected indexes.
+1. The macro `github_source` is the macro for all audit log events, whether from GitHub Enterprise Cloud or Server. The predefined maco includes examples of **BOTH**. Update to account for your specific needs.
 1. The macro `github_webhooks` is the macro used for all webhook events. Since it is assuming a single index for all webhook events, that is the predefined example, but update as needed.
-1. Finally, the macro `github_collectd` is the macro used for all collectd metrics sent from Github Enterprise Server. Please update accordingly.
+1. Finally, the macro `github_collectd` is the macro used for all collectd metrics sent from GitHub Enterprise Server. Please update accordingly.
 
 ### Integration Overview dashboard
 
-There is an *Integration Overview* dashboard listed under *Dashboards* that allows you to monitor API rate limits, audit events fetched, or webhooks received. This dashboard is primarily meant to be used with the `Github Audit Log Monitoring Add-On for Splunk` and uses internal Splunk logs. To be able to view them you will probably need elevated privileges in Splunk that include access to the `_internal` index. Please coordinate with your Splunk team if that dashboard is desired.
+There is an *Integration Overview* dashboard listed under *Dashboards* that allows you to monitor API rate limits, audit events fetched, or webhooks received. This dashboard is primarily meant to be used with the `GitHub Audit Log Monitoring Add-On for Splunk` and uses internal Splunk logs. To be able to view them you will probably need elevated privileges in Splunk that include access to the `_internal` index. Please coordinate with your Splunk team if that dashboard is desired.
 
 ## Support
 
-Support for Github App for Splunk is run through [Github Issues](https://github.com/splunk/github_app_for_splunk/issues). Please open a new issue for any support issues or for feature requests. You may also open a Pull Request if you'd like to contribute additional dashboards, eventtypes for webhooks, or enhancements you may have.
+Support for GitHub App for Splunk is run through [GitHub Issues](https://github.com/splunk/github_app_for_splunk/issues). Please open a new issue for any support issues or for feature requests. You may also open a Pull Request if you'd like to contribute additional dashboards, eventtypes for webhooks, or enhancements you may have.

--- a/github_app_for_splunk/default/app.conf
+++ b/github_app_for_splunk/default/app.conf
@@ -7,11 +7,11 @@ version = X.Y.Z
 
 [ui]
 is_visible = 1
-label = Github App for Splunk
+label = GitHub App for Splunk
 
 [launcher]
 author = Doug Erkkila
-description = Report on Activity and Audit Data from Github
+description = Report on Activity and Audit Data from GitHub
 version = X.Y.Z
 
 [package]

--- a/github_app_for_splunk/default/data/ui/views/api_config.xml
+++ b/github_app_for_splunk/default/data/ui/views/api_config.xml
@@ -12,7 +12,7 @@
 <h2 id="installation">Installation</h2>
 <ol>
 <li>
-            <p>Download the latest release of the Splunk Add-On for Github Enterprise Audit Logs from SplunkBase</p>
+            <p>Download the latest release of the Splunk Add-On for GitHub Enterprise Audit Logs from SplunkBase</p>
 </li>
 <li>
             <p>Go to Apps &gt; Manage Apps in the toolbar menu.</p>
@@ -24,7 +24,7 @@
             <p>Generate a Personal Access Token in GitHub Enterprise with the <code>site_admin</code> scope.</p>
 </li>
 <li>
-            <p>Under Settings &gt; Data inputs, there should be a new option called Github Audit Log Monitoring, click "+ Add new"</p>
+            <p>Under Settings &gt; Data inputs, there should be a new option called GitHub Audit Log Monitoring, click "+ Add new"</p>
 </li>
 <li>
             <p>Configure the Input by entering the necessary information in the input fields. Don't forget to define the Index for the data to be stored in. This option is under the "More settings" option.</p>

--- a/github_app_for_splunk/default/data/ui/views/repository_audit.xml
+++ b/github_app_for_splunk/default/data/ui/views/repository_audit.xml
@@ -97,7 +97,7 @@
     <panel>
       <title>Repository Workflow Details</title>
       <table>
-        <title>Clicking an Workflow run will take you to Github to view the Workflow</title>
+        <title>Clicking an Workflow run will take you to GitHub to view the Workflow</title>
         <search>
           <query>`github_source` action IN("workflows.completed*") repo="*" | stats latest(conclusion) as status by org, actor, name, repo, head_branch, workflow_run_id</query>
           <earliest>$timeRng.earliest$</earliest>

--- a/github_app_for_splunk/default/data/ui/views/webhook_config.xml
+++ b/github_app_for_splunk/default/data/ui/views/webhook_config.xml
@@ -3,10 +3,10 @@
   <row>
     <panel>
       <html>
-        <h1>Using Github Webhooks</h1>
-        <p>Github Webhooks are a great way to collect rich information as it occurs. You can easily enable webhooks within the Github UI and can even select specific actions on which to trigger a webhook call to Splunk. This is only available at the Organization level and will require this to be done for each Org as desired. To do so, you'll need to configure Splunk as a receiver and then setup the webhooks within Github.</p>
+        <h1>Using GitHub Webhooks</h1>
+        <p>GitHub Webhooks are a great way to collect rich information as it occurs. You can easily enable webhooks within the GitHub UI and can even select specific actions on which to trigger a webhook call to Splunk. This is only available at the Organization level and will require this to be done for each Org as desired. To do so, you'll need to configure Splunk as a receiver and then setup the webhooks within GitHub.</p>
         <h2><b>Configuring Splunk to receive Webhooks</b></h2>
-        <p>Splunk's HTTP Event Collector (HEC) is a quick and easy endpoint built to receive data from other producers like Github.</p>
+        <p>Splunk's HTTP Event Collector (HEC) is a quick and easy endpoint built to receive data from other producers like GitHub.</p>
         <p><b>Steps</b>
         <ol>
           <li>Under Settings &gt; Data Inputs, click <code>HTTP Event Collector</code></li>
@@ -15,13 +15,13 @@
           <li>Unless required by your SPlunk administrator, the rest of this page can be left as is and continue onto the next step.</li>
           <li>You'll want to click <code>select</code> for Source Type, and a new selection box will appear below that.</li>
           <li>Under the Application option, there should be an entry for <code>github_json</code>, however you may need to use the little search bar to find it.</li>
-          <li>For App Context, you'll want to select <code>Splunk App for Github</code></li>
+          <li>For App Context, you'll want to select <code>Splunk App for GitHub</code></li>
           <li>Next select the index created for this data. If none exist, create a new Index. Names like <code>github</code> or the like are recommended, depending on corporate naming conventions.</li>
           <li>Lastly, click the Review button and confirm the data is correct and hit Submit.</li>
         </ol></p>
         <p>Your token is now available to collect data, however we'll need to enable that token to allow Query String Authentication using that token. For this, you'll need command line access to your Splunk environment or be using a deployment server to deploy apps to Splunk.</p>
-        <p>To enable Query String Authentication, you'll need to update the <code>inputs.conf</code> file within the Splunk App for Github local directory. In that file, there will be a stanza with the name and value of the token you created. At the end of that stanza, you'll need to add <code>allowQueryStringAuth = true</code> and then restart Splunk. This is best done with the help of your Splunk team, so please reach out to them for assistance on this step.</p>
-        <h2><b>Setting Up Github Webhooks</b></h2>
+        <p>To enable Query String Authentication, you'll need to update the <code>inputs.conf</code> file within the Splunk App for GitHub local directory. In that file, there will be a stanza with the name and value of the token you created. At the end of that stanza, you'll need to add <code>allowQueryStringAuth = true</code> and then restart Splunk. This is best done with the help of your Splunk team, so please reach out to them for assistance on this step.</p>
+        <h2><b>Setting Up GitHub Webhooks</b></h2>
         <p>Webhooks are a simple push mechanism that will send an event each time the webhook is triggered. Unfortunately, Webhooks are unique to each Organization and will need to be setup for each Org as desired. To do this, a user will need to be an Admin for the Org.</p>
         <p><b>Steps</b></p>
         <ol>
@@ -41,26 +41,26 @@
         <table>
           <tr>
             <th>Splunk Eventtype</th>
-            <th>Github Webhook Event</th>
+            <th>GitHub Webhook Event</th>
             <th>Description</th>
           </tr>
           <tr>
-            <td>Github::Repo</td>
+            <td>GitHub::Repo</td>
             <td>Repositories</td>
             <td>Repository created, deleted, archived, unarchived, publicized, privatized, edited, renamed, or transferred.</td>
           </tr>
           <tr>
-            <td>Github::Push</td>
+            <td>GitHub::Push</td>
             <td>Pushes</td>
             <td>Git push to a repository.</td>
           </tr>
           <tr>
-            <td>Github::PullRequest</td>
+            <td>GitHub::PullRequest</td>
             <td>Pull requests</td>
             <td>Pull request opened, closed, reopened, edited, assigned, unassigned, review requested, review request removed, labeled, unlabeled, synchronized, ready for review, converted to draft, locked, unlocked, auto merge enabled, auto merge disabled, milestoned, or demilestoned.</td>
           </tr>
           <tr>
-            <td>Github::PullRequest::Review</td>
+            <td>GitHub::PullRequest::Review</td>
             <td>Pull request reviews</td>
             <td>Pull request review submitted, edited, or dismissed.</td>
           </tr>


### PR DESCRIPTION
Fixes https://github.com/splunk/github_app_for_splunk/issues/19.  

I attempted to get all the references to `Github` changed to `GitHub` WITHOUT changing anything that might impact the functionality of the app.  @derkkila can you give me some 👀  on this?