### PR TITLE
changing wrong formula to calculate percentages

### DIFF
--- a/github_app_for_splunk/default/savedsearches.conf
+++ b/github_app_for_splunk/default/savedsearches.conf
@@ -38,7 +38,8 @@ search = | mstats avg(_value) as "Avg" WHERE `github_collectd` AND metric_name="
 | eval metric_name=mvindex(split(metric_name,"."),2)\
 | stats avg("disk_gb") as "Avg" by metric_name, host\
 | xyseries host metric_name Avg\
-| eval disk_util=(used/free)*100\
+| eval disk_total=used+free\
+| eval disk_util=(used/disk_total)*100\
 | fields host disk_util
 
 [GitHub Disk Utilization Over 85%]
@@ -82,7 +83,8 @@ search = | mstats avg(_value) as "Avg" WHERE `github_collectd` AND metric_name="
 | eval metric_name=mvindex(split(metric_name,"."),2)\
 | stats avg("disk_gb") as "Avg" by metric_name, host\
 | xyseries host metric_name Avg\
-| eval disk_util=(used/free)*100\
+| eval disk_total=used+free\
+| eval disk_util=(used/disk_total)*100\
 | fields host disk_util
 
 [GitHub Load Average Above 1]


### PR DESCRIPTION
A percentage should be defined by used/total * 100. This is currently being defined as used/free * 100, leading to unexpected calculations and alerts.