### PR TITLE
Changed function max to avg for avg CPU load

### DIFF
--- a/github_app_for_splunk/default/savedsearches.conf
+++ b/github_app_for_splunk/default/savedsearches.conf
@@ -121,6 +121,6 @@ display.visualizations.custom.type = sunburst_viz.sunburst_viz
 enableSched = 1
 request.ui_dispatch_app = github_app_for_splunk
 request.ui_dispatch_view = search
-search = | mstats max(_value) as "Max" WHERE `github_collectd` AND metric_name="load.longterm" AND host="*" span=10s BY metric_name, host\
-| stats max(Max) as "Load" by metric_name, host\
+search = | mstats avg(_value) as "Avg" WHERE `github_collectd` AND metric_name="load.longterm" AND host="*" span=10s BY metric_name, host\
+| stats avg(Avg) as "Load" by metric_name, host\
 | xyseries host metric_name Load


### PR DESCRIPTION
Current function shows the maximum value registered on a determinate time frame, fetching data every 10s. The description suggest this is not the desired result: an average should be calculated instead.