### PR TITLE
Advanced Security Overview Dashboard - Update color palette on Open Alerts By Severity

### DIFF
--- a/github_app_for_splunk/default/data/ui/views/security_alert_overview.xml
+++ b/github_app_for_splunk/default/data/ui/views/security_alert_overview.xml
@@ -62,6 +62,9 @@
         <option name="charting.chart.stackMode">default</option>
         <option name="charting.chart.style">shiny</option>
         <option name="charting.drilldown">none</option>
+        <option name="charting.fieldColors">
+          {"critical": 0xDC4E41, "high": 0xF1813F, "medium":0xF8BE34, "moderate":0xF8BE34, "low":0xC9D1D9}
+        </option>
         <option name="charting.layout.splitSeries">0</option>
         <option name="charting.layout.splitSeries.allowIndependentYRanges">0</option>
         <option name="charting.legend.labelStyle.overflowMode">ellipsisMiddle</option>


### PR DESCRIPTION
Apply Chart Visualization customization: https://docs.splunk.com/Documentation/Splunk/8.2.6/Viz/ChartConfigurationReference


Before
![image](https://user-images.githubusercontent.com/1760475/162809326-1e6a07fa-f637-4742-a578-255dd37331d0.png)


After
![image](https://user-images.githubusercontent.com/1760475/162809250-9c5d15c0-7c25-4824-bba9-3dff20403539.png)

Cant seem to find any official Advanced Security color palette, therefore:
- re-used the color scheme already in place on Alert Details table
- used a shade of grey for `low` as seen in Dependabot key
   - ![image](https://user-images.githubusercontent.com/1760475/162815021-74ac3857-dc74-49cb-a233-3753314fcf3a.png)

