### PR TITLE
Remove macros from eventtypes.

### DIFF
--- a/github_app_for_splunk/default/eventtypes.conf
+++ b/github_app_for_splunk/default/eventtypes.conf
@@ -1,41 +1,41 @@
 [GitHub::Issue]
-search = `github_webhooks` action IN ("opened","edited","deleted","pinned","unpinned","closed","reopened","assigned","unassigned","labeled","unlabeled","locked","unlocked","transferred","milestoned","demilestoned") "issue.number"=* NOT "comment.body"=*
+search = action IN ("opened","edited","deleted","pinned","unpinned","closed","reopened","assigned","unassigned","labeled","unlabeled","locked","unlocked","transferred","milestoned","demilestoned") "issue.number"=* NOT "comment.body"=*
 
 [GitHub::Issue::Comment]
-search = `github_webhooks` action IN ("created","edited","deleted") "issue.number"=* "comment.body"=*
+search = action IN ("created","edited","deleted") "issue.number"=* "comment.body"=*
 
 [GitHub::PullRequest]
-search = `github_webhooks` action IN ("opened","edited","closed","assigned","unassigned","review_requested","review_request_removed","ready_for_review","converted_to_draft","labeled","unlabeled","synchronize","auto_merge_enabled","auto_merge_disabled","locked","unlocked","reopened") number=* "pull_request.id"=*
+search = action IN ("opened","edited","closed","assigned","unassigned","review_requested","review_request_removed","ready_for_review","converted_to_draft","labeled","unlabeled","synchronize","auto_merge_enabled","auto_merge_disabled","locked","unlocked","reopened") number=* "pull_request.id"=*
 
 [GitHub::PullRequest::Review]
-search = `github_webhooks` action IN ("submitted","edited","dismissed") pull_request.id=* review.id=*
+search = action IN ("submitted","edited","dismissed") pull_request.id=* review.id=*
 
 [GitHub::Push]
-search = `github_webhooks` after=* before=* "commits{}.id"=* ref=* "pusher.name"=*
+search = after=* before=* "commits{}.id"=* ref=* "pusher.name"=*
 
 [GitHub::Repo]
-search = `github_webhooks` action IN ("created","deleted","archived","unarchived","edited","renamed","transferred","publicized","privatized") "repository.name"=* NOT "pull_request.id"=* NOT "project_card.id"=* NOT "project.number"=* NOT "project_column.id"=* NOT "check_run.id"=* NOT "alert.created_at"=* NOT "alert.number"=*
+search = action IN ("created","deleted","archived","unarchived","edited","renamed","transferred","publicized","privatized") "repository.name"=* NOT "pull_request.id"=* NOT "project_card.id"=* NOT "project.number"=* NOT "project_column.id"=* NOT "check_run.id"=* NOT "alert.created_at"=* NOT "alert.number"=*
 
 [GitHub::Project]
-search = `github_webhooks` action IN ("created","edited","closed","reopenend","deleted") "project.number"=*
+search = action IN ("created","edited","closed","reopenend","deleted") "project.number"=*
 
 [GitHub::Project::Card]
-search = `github_webhooks` action IN ("created","edited","moved","converted","deleted") "project_card.id"=*
+search = action IN ("created","edited","moved","converted","deleted") "project_card.id"=*
 
 [GitHub::Project::Column]
-search = `github_webhooks`  action IN ("created","edited","moved","deleted") "project_column.id"=*
+search = action IN ("created","edited","moved","deleted") "project_column.id"=*
 
 [GitHub::Workflow]
-search = `github_webhooks` action IN ("queued","created","in_progress","completed") workflow_job.id=*
+search = action IN ("queued","created","in_progress","completed") workflow_job.id=*
 
 [GitHub::CodeScanning]
-search = `github_webhooks` action IN ("appeared_in_branch", "closed_by_user", "created", "fixed", "reopened", "reopened_by_user") "alert.created_at"=*
+search = action IN ("appeared_in_branch", "closed_by_user", "created", "fixed", "reopened", "reopened_by_user") "alert.created_at"=*
 
 [GitHub::SecretScanning]
-search = `github_webhooks` action IN ("created", "resolved") "alert.secret_type"=*
+search = action IN ("created", "resolved") "alert.secret_type"=*
 
 [GitHub::VulnerabilityAlert]
-search = `github_webhooks` action IN ("create", "dismiss", "resolve") "alert.external_identifier"=*
+search = action IN ("create", "dismiss", "resolve") "alert.external_identifier"=*
 
 [GitHub::Release]
-search = `github_webhooks` action IN ("released","published") release.id=*
+search = action IN ("released","published") release.id=*


### PR DESCRIPTION
Macros are not pushed down to the indexers. This causes issues when searches use eventypes with macros inside them. All the dashboards already specify the macro, so why duplicate it in the eventtype? This will help fix app installs in Splunk Cloud where we don't have access to easily push the macros down to the indexers.