### PR TITLE
Advanced Security Overview - Fix broken DrillDown deeplink to security alerts

### DIFF
--- a/github_app_for_splunk/default/data/ui/views/security_alert_overview.xml
+++ b/github_app_for_splunk/default/data/ui/views/security_alert_overview.xml
@@ -4,8 +4,9 @@
     <query>
     index=gh_vuln OR (`github_webhooks` alert.created_at=*) 
     | eval type=case((eventtype="GitHub::CodeScanning"), "Code Scanning Alert", (eventtype="GitHub::VulnerabilityAlert"), "Dependabot Alert", (eventtype="GitHub::SecretScanning"), "Secret Scanning Alert") 
-    | eval reason=case((type="Dependabot Alert"),'alert.affected_package_name',(type="Code Scanning Alert"), 'alert.rule.name', (type="Secret Scanning Alert"), 'alert.secret_type'), id=case((type="Dependabot Alert"),'alert.external_identifier',(type="Code Scanning Alert"), 'alert.rule.id', (type="Secret Scanning Alert"), 'alert.number'), severity=case((type="Dependabot Alert"),'alert.severity',(type="Code Scanning Alert"), 'alert.rule.security_severity_level', (type="Secret Scanning Alert"), "high")
-    | stats latest(action) as status, earliest(alert.created_at) as created_at, latest(alert.number) as number by repository.full_name, reason, id, type, severity 
+    | eval url=case((eventtype="GitHub::CodeScanning"), urldecode('alert.html_url'), (eventtype="GitHub::VulnerabilityAlert"), urldecode('repository.html_url'+"/security/dependabot/"+'alert.number'), (eventtype="GitHub::SecretScanning"), urldecode('alert.html_url'))    
+    | eval reason=case((type="Dependabot Alert"),'alert.affected_package_name',(type="Code Scanning Alert"), 'alert.rule.name', (type="Secret Scanning Alert"), 'alert.secret_type'), id=case((type="Dependabot Alert"),'alert.external_identifier',(type="Code Scanning Alert"), 'alert.rule.id', (type="Secret Scanning Alert"), 'alert.number'), severity=case((type="Dependabot Alert"),'alert.severity',(type="Code Scanning Alert"), 'alert.rule.security_severity_level', (type="Secret Scanning Alert"), "high"), repository = 'repository.full_name'
+    | stats latest(action) as status, earliest(alert.created_at) as created_at, latest(alert.number) as number by repository, reason, id, type, severity, url
     | eval source=type
     | eval age = toString(round(now() - strptime(created_at, "%Y-%m-%dT%H:%M:%S")),"Duration") 
     | search severity IN("*") status IN("*") type IN("*") 
@@ -88,7 +89,7 @@
       <title>Open Alerts By Repository</title>
       <chart>
         <search base="baseSearch">
-          <query>| search status IN("create","created") | stats count by repository.full_name</query>
+          <query>| search status IN("create","created") | stats count by repository</query>
         </search>
         <option name="charting.axisLabelsX.majorLabelStyle.overflowMode">ellipsisNone</option>
         <option name="charting.axisLabelsX.majorLabelStyle.rotation">0</option>
@@ -239,11 +240,9 @@
         <search base="baseSearch">
           <query>|search severity IN($severityTkn$) status IN($statusTkn$) type IN($typeTkn$) | sort -age</query>
         </search>
-        <fields>repository.full_name, reason, id, type,severity,status, created_at, age</fields>
+        <fields>repository, reason, id, type,severity,status, created_at, age</fields>
         <drilldown target="_blank">
-          <link>
-            https://github.com/$row.repository.full_name|n$/security/$row.source$/$row.number$
-          </link>
+          <link>$row.url|n$</link>
         </drilldown>
         <option name="count">20</option>
         <option name="dataOverlayMode">none</option>

--- a/github_app_for_splunk/default/data/ui/views/security_alert_overview.xml
+++ b/github_app_for_splunk/default/data/ui/views/security_alert_overview.xml
@@ -4,7 +4,7 @@
     <query>
     index=gh_vuln OR (`github_webhooks` alert.created_at=*) 
     | eval type=case((eventtype="GitHub::CodeScanning"), "Code Scanning Alert", (eventtype="GitHub::VulnerabilityAlert"), "Dependabot Alert", (eventtype="GitHub::SecretScanning"), "Secret Scanning Alert") 
-    | eval url=case((eventtype="GitHub::CodeScanning"), urldecode('alert.html_url'), (eventtype="GitHub::VulnerabilityAlert"), urldecode('repository.html_url'+"/security/dependabot/"+'alert.number'), (eventtype="GitHub::SecretScanning"), urldecode('alert.html_url'))    
+    | eval url=case((eventtype="GitHub::CodeScanning"), 'alert.html_url', (eventtype="GitHub::VulnerabilityAlert"), 'repository.html_url'+"/security/dependabot/"+'alert.number', (eventtype="GitHub::SecretScanning"), 'alert.html_url')    
     | eval reason=case((type="Dependabot Alert"),'alert.affected_package_name',(type="Code Scanning Alert"), 'alert.rule.name', (type="Secret Scanning Alert"), 'alert.secret_type'), id=case((type="Dependabot Alert"),'alert.external_identifier',(type="Code Scanning Alert"), 'alert.rule.id', (type="Secret Scanning Alert"), 'alert.number'), severity=case((type="Dependabot Alert"),'alert.severity',(type="Code Scanning Alert"), 'alert.rule.security_severity_level', (type="Secret Scanning Alert"), "high"), repository = 'repository.full_name'
     | stats latest(action) as status, earliest(alert.created_at) as created_at, latest(alert.number) as number by repository, reason, id, type, severity, url
     | eval source=type


### PR DESCRIPTION
- [x] parse out url from webhook based on eventtype 
   - [x] dependabot urls must be built manually - not in alert   `'repository.html_url'+"/security/dependabot/"+'alert.number'`
- [x] render drilldown url + [`|n` trick w/o escaping special chars in url](https://community.splunk.com/t5/Dashboards-Visualizations/How-to-drill-down-from-a-Splunk-dashboard-to-an-external-URL/m-p/234382)
- [x] use friendly name for `repository` vs json `repository.full_name`

# Clicking row in drilldown

## Before (404s)
- Dependabot link: https://github.com/octodemo/demo-vulnerabilities-ghas/security/Dependabot%20Alert/3
- Secret Scanning link: https://github.com/octodemo/demo-vulnerabilities-ghas/security/Secret%20Scanning%20Alert/14
- Code Scanning link: https://github.com/octodemo/demo-vulnerabilities-ghas/security/Code%20Scanning%20Alert/83

## After
- Dependabot link: https://github.com/octodemo/demo-vulnerabilities-ghas/security/dependabot/3
- Secret Scanning link: https://github.com/octodemo/demo-vulnerabilities-ghas/security/secret-scanning/14
- Code Scanning link: https://github.com/octodemo/demo-vulnerabilities-ghas/security/code-scanning/83
