### PR TITLE
Add resolved field to the closed alert count

### DIFF
--- a/github_app_for_splunk/default/data/ui/views/security_alert_overview.xml
+++ b/github_app_for_splunk/default/data/ui/views/security_alert_overview.xml
@@ -168,7 +168,7 @@
       <title>Resolved Alert Count</title>
       <single>
         <search base="baseSearch">
-          <query>| search status IN("dismiss","resolve","closed_by_user","fixed")| stats count</query>
+          <query>| search status IN("dismiss","resolve","resolved","closed_by_user","fixed")| stats count</query>
         </search>
         <option name="colorBy">value</option>
         <option name="colorMode">none</option>


### PR DESCRIPTION
This change causes the `Resolved alert count` metric to also count secret scanning alerts that have been closed.

fixes #51 