### PR TITLE
Narrow CodeScanning eventtypes again

### DIFF
--- a/github_app_for_splunk/default/eventtypes.conf
+++ b/github_app_for_splunk/default/eventtypes.conf
@@ -5,7 +5,7 @@ search = `github_webhooks` ref_type=branch
 search = `github_source` action=* sourcetype="github:enterprise:audit" OR sourcetype="github_audit"
 
 [GitHub::CodeScanning]
-search = `github_webhooks` action IN ("appeared_in_branch", "closed_by_user", "created", "fixed", "reopened", "reopened_by_user") "alert.created_at"=*
+search = `github_webhooks` action IN ("appeared_in_branch", "closed_by_user", "created", "fixed", "reopened", "reopened_by_user") "commit_oid"=*
 
 [GitHub::CodeVulnerability]
 search = `github_webhooks` (eventtype="GitHub::CodeScanning") "alert.html_url"="*/security/code-scanning/*"


### PR DESCRIPTION
Narrow CodeScanning eventtype definition.

In PR https://github.com/splunk/github_app_for_splunk/pull/35 @leftrightleft narrowed the eventtype for CodeScanning events but then was (accidently?) reverted by https://github.com/splunk/github_app_for_splunk/pull/37. This change narrows the eventtype again.